### PR TITLE
optim slice_update in compute_loss

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -167,7 +167,7 @@ class ComputeLoss:
                     t = flow.full_like(pcls, self.cn, device=self.device)  # targets
 
                     # t[range(n), tcls[i]] = self.cp
-                    t[flow.arange(n).to(self.device), tcls[i]] = self.cp
+                    t[flow.arange(n, device=self.device), tcls[i]] = self.cp
 
                     lcls = lcls + self.BCEcls(pcls, t)  # BCE
 
@@ -234,7 +234,7 @@ class ComputeLoss:
             anchors, shape = self.anchors[i], p[i].shape
 
             # gain[2:6] = flow.tensor(shape)[[3, 2, 3, 2]]  # xyxy gain
-            gain[2:6] = flow.tensor(p[i].shape)[[3, 2, 3, 2]].float()  # xyxy gain
+            gain[2:6] = flow.tensor(p[i].shape, device=self.device)[[3, 2, 3, 2]].float()  # xyxy gain
 
             # Match targets to anchors
             t = targets * gain  # shape(3,n,7)


### PR DESCRIPTION
此pr可以为每个batch的compute_loss部分减少一次h2d和cpu slice_update操作。

main分支。
<img width="415" alt="图片" src="https://user-images.githubusercontent.com/35585791/198231922-f622f9b3-e599-4026-b426-8850d64be211.png">

此pr:

![图片](https://user-images.githubusercontent.com/35585791/198232130-36a2ca5f-0e58-4aaa-81be-f89752a9bfe4.png)
