### PR TITLE
fix_verify_zip_in_experimental

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -76,7 +76,7 @@ def attempt_load(weights, device=None, inplace=True, fuse=True):
     model = Ensemble()
     if isinstance(weights, str) and weights.endswith(".zip"):
         weights = weights.replace(".zip", "")
-        
+
     for w in weights if isinstance(weights, list) else [weights]:
         ckpt = flow.load(attempt_download(w), map_location="cpu")  # load
         ckpt = (ckpt.get("ema") or ckpt["model"]).to(device).float()  # FP32 model

--- a/models/experimental.py
+++ b/models/experimental.py
@@ -74,8 +74,9 @@ def attempt_load(weights, device=None, inplace=True, fuse=True):
     from models.yolo import Detect, Model
 
     model = Ensemble()
-    if ".zip" in weights:
-        weights = weights[:-4]
+    if isinstance(weights, str) and weights.endswith(".zip"):
+        weights = weights.replace(".zip", "")
+        
     for w in weights if isinstance(weights, list) else [weights]:
         ckpt = flow.load(attempt_download(w), map_location="cpu")  # load
         ckpt = (ckpt.get("ema") or ckpt["model"]).to(device).float()  # FP32 model


### PR DESCRIPTION
此pr可以在修复，如下判断https://github.com/Oneflow-Inc/one-yolov5/blob/c5caab6b0896270db084e78ea8f7206bd7f6d816/models/experimental.py#L77 

因为 weights类型可能为 <class 'pathlib.PosixPath'> 导致的错误。