### PR TITLE
Fix type error in dataloaders

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -724,7 +724,8 @@ class LoadImagesAndLabels(Dataset):
 
         labels_out = flow.zeros((nl, 6))
         if nl:
-            labels_out[:, 1:] = flow.from_numpy(labels)
+            # labels_out[:, 1:] = flow.from_numpy(labels)
+            labels_out[:, 1:] = flow.from_numpy(labels).to(labels_out.dtype)
 
         # Convert
         img = img.transpose((2, 0, 1))[::-1]  # HWC to CHW, BGR to RGB

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -724,6 +724,7 @@ class LoadImagesAndLabels(Dataset):
 
         labels_out = flow.zeros((nl, 6))
         if nl:
+            # TODO(fengwen): 修改下一行绕过 TypeError: Tensors ref and value must have same type
             # labels_out[:, 1:] = flow.from_numpy(labels)
             labels_out[:, 1:] = flow.from_numpy(labels).to(labels_out.dtype)
 


### PR DESCRIPTION
此pr可以修复dataloaders.py 文件 labels_out[:, 1:] = flow.from_numpy(labels)这一行 导致的 TypeError: Tensors ref and value must have same type 。