### PR TITLE
fix_sync_jammed_in_oneflow_utils.py

### DIFF
--- a/utils/oneflow_utils.py
+++ b/utils/oneflow_utils.py
@@ -88,8 +88,9 @@ def select_device(device="", batch_size=0, newline=True):
 
 def time_sync():
     # oneflow-accurate time
-    if flow.cuda.is_available():
-        flow.cuda.synchronize()
+    # TODO(fengwen):在ddp训练计算loss时候卡死,暂时注释下面两行，先绕过
+    # if flow.cuda.is_available():
+    #     flow.cuda.synchronize()
     return time.time()
 
 


### PR DESCRIPTION
此pr暂时绕过在ddp训练计算loss时候，调用time_sync（）函数获取时间卡死。issues地址:  [https://github.com/Oneflow-Inc/oneflow/issues/9338](https://github.com/Oneflow-Inc/oneflow/issues/9338)