### PR TITLE
One yolov5 support wandb train

### DIFF
--- a/train.py
+++ b/train.py
@@ -408,7 +408,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             # stop = stopper(epoch=epoch, fitness=fi)  # early stop check
             if fi > best_fitness:
                 best_fitness = fi
-            log_vals = list(mloss) + list(results) + lr
+            log_vals = mloss.tolist() + list(results) + lr
             callbacks.run("on_fit_epoch_end", log_vals, epoch, best_fitness, fi)
 
             # Save model
@@ -431,7 +431,6 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                     model_save(ckpt, best)  # flow.save(ckpt, best)
 
                 if opt.save_period > 0 and epoch % opt.save_period == 0:
-                    print("is ok")
                     model_save(ckpt, w / f"epoch{epoch}")  # flow.save(ckpt, w / f"epoch{epoch}")
                 del ckpt
                 callbacks.run("on_model_save", last, epoch, final_epoch, best_fitness, fi)

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -540,7 +540,7 @@ class WandbLogger:
                     for *xyxy, conf, cls in pred.tolist()
                 ]
                 boxes = {"predictions": {"box_data": box_data, "class_labels": names}}  # inference-space
-                self.bbox_media_panel_images.append(wandb.Image(im.permute(1,2,0), boxes=boxes, caption=path.name))
+                self.bbox_media_panel_images.append(wandb.Image(im.permute(1, 2, 0), boxes=boxes, caption=path.name))
 
     def log(self, log_dict):
         """

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -540,7 +540,7 @@ class WandbLogger:
                     for *xyxy, conf, cls in pred.tolist()
                 ]
                 boxes = {"predictions": {"box_data": box_data, "class_labels": names}}  # inference-space
-                self.bbox_media_panel_images.append(wandb.Image(im, boxes=boxes, caption=path.name))
+                self.bbox_media_panel_images.append(wandb.Image(im.permute(1,2,0), boxes=boxes, caption=path.name))
 
     def log(self, log_dict):
         """


### PR DESCRIPTION
此pr修复 项目中 `wandb` 对实验跟踪和可视化功能的支持。

## 简单二步即可开始记录机器学习实验。
### 1. 安装库
```shell
pip install wandb
```
### 2. 创建账号
注册页注册一个[免费账号](https://wandb.ai/login?signup=true)。

![image](https://user-images.githubusercontent.com/109639975/204803891-9e0bdd4f-05b3-40d4-8b26-f609d8123f2f.png)

终端输入
```shell 
wandb login
```
终端输入后粘贴copy的key 输入回车确认 ，大工告成。

## 验证
使用指令 ` python train.py --weights ' ' --data data/coco128.yaml --cfg models/yolov5s.yaml `
成功运行示例如下:
![image](https://user-images.githubusercontent.com/109639975/204806938-58fe5e40-b82a-4584-b764-8ea4f2107091.png)

通过wandb: 🚀 View run at：xxx链接即可查看 使用wandb可视化的结果。

